### PR TITLE
Reform Manifest With Proper Descriptions.

### DIFF
--- a/cm14_manifest.xml
+++ b/cm14_manifest.xml
@@ -21,6 +21,8 @@
 
   <remove-project name="platform/sdk" />
 
+  
+ <!-- TWRP -->
   <project path="bootable/recovery-twrp" name="omnirom/android_bootable_recovery" remote="github" revision="android-7.1"/>
 
   
@@ -56,7 +58,7 @@
   <project path="device/samsung/j5ltechn" name="Galaxy-MSM8916/android_device_samsung_j5ltechn" groups="device" remote="github"/>
 
   
- <!-- Galaxy J7 Device Trees -->
+ <!-- Galaxy J7 Device Tree SM-J700P -->
   <project path="device/samsung/j7lte-common" name="Galaxy-MSM8916/android_device_samsung_j7lte-common" groups="device" remote="github"/>
   <project path="device/samsung/j7ltespr" name="Galaxy-MSM8916/android_device_samsung_j7ltespr" groups="device" remote="github"/>
 

--- a/cm14_manifest.xml
+++ b/cm14_manifest.xml
@@ -23,12 +23,18 @@
 
   <project path="bootable/recovery-twrp" name="omnirom/android_bootable_recovery" remote="github" revision="android-7.1"/>
 
+  
+  <!-- Qcom Common -->
   <project path="device/qcom-common" name="LineageOS/android_device_qcom_common"/>
 
+  
+  <!-- Grand Prime Fortuna Device Trees -->
   <project path="device/samsung/fortuna3g" name="Galaxy-MSM8916/android_device_samsung_fortuna3g" groups="device" remote="github"/>
   <project path="device/samsung/fortunalteub" name="Galaxy-MSM8916/android_device_samsung_fortunalteub" groups="device" remote="github"/>
   <project path="device/samsung/fortunave3g" name="Galaxy-MSM8916/android_device_samsung_fortunave3g" groups="device" remote="github"/>
 
+  
+  <!-- Grand Prime G530FZ-T-T1-W Device Trees -->
   <project path="device/samsung/gprimelte" name="LineageOS/android_device_samsung_gprimelte" groups="device" remote="github"/>
   <project path="device/samsung/gprimelte-common" name="LineageOS/android_device_samsung_gprimelte-common" groups="device" remote="github"/>
   <project path="device/samsung/gprimeltespr" name="LineageOS/android_device_samsung_gprimeltespr" groups="device" remote="github"/>
@@ -36,31 +42,45 @@
   <project path="device/samsung/gprimeltexx" name="LineageOS/android_device_samsung_gprimeltexx" groups="device" remote="github"/>
   <project path="device/samsung/gprimeltezt" name="Galaxy-MSM8916/android_device_samsung_gprimeltezt" groups="device" remote="github"/>
 
+  
+  <!-- Galaxy Tab E (SM-T377P - gtesqltespr) && (SM-T560NU - gtelwifiue) -->
   <project path="device/samsung/gte-common" name="LineageOS/android_device_samsung_gte-common" groups="device" remote="github"/>
   <project path="device/samsung/gtelwifiue" name="LineageOS/android_device_samsung_gtelwifiue" groups="device" remote="github"/>
   <project path="device/samsung/gtesqltespr" name="LineageOS/android_device_samsung_gtesqltespr" groups="device" remote="github"/>
 
+  
+ <!-- Galaxy J5 Device Trees -->
   <project path="device/samsung/j5-common" name="Galaxy-MSM8916/android_device_samsung_j5-common" groups="device" remote="github"/>
   <project path="device/samsung/j53gxx" name="Galaxy-MSM8916/android_device_samsung_j53gxx" groups="device" remote="github"/>
   <project path="device/samsung/j5lte" name="Galaxy-MSM8916/android_device_samsung_j5lte" groups="device" remote="github"/>
   <project path="device/samsung/j5ltechn" name="Galaxy-MSM8916/android_device_samsung_j5ltechn" groups="device" remote="github"/>
 
+  
+ <!-- Galaxy J7 Device Trees -->
   <project path="device/samsung/j7lte-common" name="Galaxy-MSM8916/android_device_samsung_j7lte-common" groups="device" remote="github"/>
   <project path="device/samsung/j7ltespr" name="Galaxy-MSM8916/android_device_samsung_j7ltespr" groups="device" remote="github"/>
 
+  
+ <!-- Samsung MSM8916 Common Repos -->
   <project path="device/samsung/msm8916-common" name="LineageOS/android_device_samsung_msm8916-common" groups="device" remote="github"/>
-
   <project path="device/samsung/qcom-common" name="LineageOS/android_device_samsung_qcom-common" groups="device" />
 
+  
+ <!-- Dependencies -->
   <project path="external/busybox" name="LineageOS/android_external_busybox" />
   <project path="external/sony/boringssl-compat" name="LineageOS/android_external_sony_boringssl-compat" />
   <project path="external/stlport" name="LineageOS/android_external_stlport"/>
-
+  <project path="packages/resources/devicesettings" name="LineageOS/android_packages_resources_devicesettings"/>
+  
+  
+ <!-- Samsung Hardware Repo -->
   <project path="hardware/samsung" name="LineageOS/android_hardware_samsung"/>
 
+  
+ <!-- Common Samsung MSM8916 Kernel -->
   <project path="kernel/samsung/msm8916" name="LineageOS/android_kernel_samsung_msm8916" remote="github"/>
 
-  <project path="packages/resources/devicesettings" name="LineageOS/android_packages_resources_devicesettings"/>
-
+  
+ <!-- Vendor Trees For All Device Trees -->
   <project path="vendor/samsung" name="Galaxy-MSM8916/proprietary_vendor_samsung" groups="device" remote="github"/>
 </manifest>


### PR DESCRIPTION
It is better to identify the devices this way & will be easier to comment out any unneeded repos while syncing. It'll be improved overtime. Tho I feel all common device trees should be under a single header as   <!-- Common Trees -->